### PR TITLE
Add 'Ask the Bot' button for StevesBot triage integration

### DIFF
--- a/NinjaBot/cogs/NinjaThreadManager.py
+++ b/NinjaBot/cogs/NinjaThreadManager.py
@@ -2,6 +2,7 @@
 import logging
 import re
 import discord
+import aiohttp
 import utils.embedBuilder as embedBuilder
 import utils.ai as ai
 from datetime import datetime, timedelta, timezone
@@ -37,12 +38,16 @@ class ThreadManagementButtons(discord.ui.View):
     async def titleButton(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
         await interaction.response.send_modal(ThreadTitleChangeModal(self.ntm, getattr(interaction.channel, "name")))
 
+    @discord.ui.button(label="Ask the Bot", style=discord.ButtonStyle.secondary, custom_id="ask_bot", emoji="🤖")
+    async def askBotButton(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        await self.ntm._askBot(interaction)
+
     # Check if user is Moderator before calling callbacks
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        # allow a user to close their own thread
+        custom_id = interaction.data.get("custom_id") if interaction.data else None
+        # allow a user to close their own thread or ask the bot
         if hasattr(interaction, "user") and interaction.user.id == self.threadCreationUser \
-            and hasattr(interaction, "data") and interaction.data is not None and "custom_id" in interaction.data \
-            and interaction.data.get("custom_id") == "close":
+            and custom_id in ("close", "ask_bot"):
             return True
         # allow moderators to do everything everywhere
         if hasattr(interaction, "message") and hasattr(interaction.user, "roles") and discord.utils.get(getattr(interaction.user, "roles"), name="Moderator"):
@@ -88,6 +93,7 @@ class NinjaThreadManager(commands.Cog):
         self.bot = bot
         self.isInternal = True
         self.ai = ai.NinjaAI(bot)
+        self.http = aiohttp.ClientSession()
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message) -> None:
@@ -307,6 +313,60 @@ class NinjaThreadManager(commands.Cog):
         await interaction.response.send_message(f"Thread was archived by {interaction.user.display_name}. Anyone can send a message to unarchive it.")
         if not interaction.channel.archived: await interaction.channel.edit(archived=True, reason="NinjaBot")
 
+    async def _askBot(self, interaction) -> None:
+        """Trigger StevesBot's interactive triage flow in the current thread."""
+        if not isinstance(interaction.channel, discord.Thread):
+            await interaction.response.send_message("This can only be used in a thread.", ephemeral=True)
+            return
+
+        api_url = self.bot.config.get("stevesbotApiUrl") if self.bot.config.has("stevesbotApiUrl") else None
+        if not api_url:
+            await interaction.response.send_message("Support bot is not configured.", ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True)
+
+        # Determine product from parent channel mapping
+        channel_products = self.bot.config.get("stevesbotChannelProducts") if self.bot.config.has("stevesbotChannelProducts") else {}
+        parent_id = str(interaction.channel.parent_id) if interaction.channel.parent_id else ""
+        preselected_product = channel_products.get(parent_id)
+
+        # Use the thread starter message ID as trigger, fall back to thread ID
+        try:
+            starter = await interaction.channel.fetch_message(interaction.channel.id)
+            trigger_message_id = str(starter.id)
+        except Exception:
+            trigger_message_id = str(interaction.channel.id)
+
+        payload = {
+            "channelId": str(interaction.channel.id),
+            "userId": str(interaction.user.id),
+            "triggerMessageId": trigger_message_id,
+        }
+        if preselected_product:
+            payload["preselectedProduct"] = preselected_product
+
+        try:
+            async with self.http.post(f"{api_url}/api/start-triage", json=payload) as resp:
+                if resp.status == 200:
+                    await interaction.followup.send(
+                        "🤖 The support bot is now active! Follow the prompts below to get help.",
+                        ephemeral=True,
+                    )
+                else:
+                    error_text = await resp.text()
+                    logger.warning(f"StevesBot API returned {resp.status}: {error_text}")
+                    await interaction.followup.send(
+                        "Sorry, the support bot is unavailable right now. Please wait for human assistance.",
+                        ephemeral=True,
+                    )
+        except Exception as e:
+            logger.exception(f"Error calling StevesBot API: {e}")
+            await interaction.followup.send(
+                "Sorry, the support bot is unavailable right now. Please wait for human assistance.",
+                ephemeral=True,
+            )
+
     @app_commands.command()
     @app_commands.guild_only()
     @app_commands.checks.has_permissions(manage_messages=True)
@@ -432,6 +492,8 @@ class NinjaThreadManager(commands.Cog):
         logger.debug(f"Shutting down {self.__class__.__name__}")
         if self.ai:
             await self.ai.close()
+        if self.http and not self.http.closed:
+            await self.http.close()
 
 async def setup(bot) -> None:
     await bot.add_cog(NinjaThreadManager(bot))

--- a/NinjaBot/discordbot.sample.cfg
+++ b/NinjaBot/discordbot.sample.cfg
@@ -72,6 +72,13 @@
         "FEATURE_REQUESTS_CHANNEL_ID": "You are helping in the #feature-requests channel. Acknowledge the request and note if similar features exist."
     },
 
+    "_comment_stevesbot": "StevesBot integration - interactive support triage via external bot",
+    "stevesbotApiUrl": "http://YOUR_STEVESBOT_HOST:8787",
+    "stevesbotChannelProducts": {
+        "SUPPORT_CHANNEL_ID": "vdo-ninja",
+        "SOCIAL_STREAM_CHANNEL_ID": "social-stream"
+    },
+
     "_comment_services": "Freelancer services approval system",
     "servicesChannel": "PRIVATE_REVIEW_CHANNEL_ID",
     "servicesAnnounceChannel": "PUBLIC_ANNOUNCE_CHANNEL_ID",


### PR DESCRIPTION
## Summary
- Adds an **Ask the Bot** 🤖 button to the thread management buttons (alongside Close Thread and Change Title)
- When a user clicks it, the bot calls StevesBot's `/api/start-triage` endpoint to start an interactive support triage flow in the thread
- Thread creators can use the button (same permission as Close Thread) — no moderator role needed
- Product is auto-detected from the parent channel via config mapping (e.g., VDO.Ninja support channel → skips product selection)

## Config
Add to `discordbot.cfg`:
```json
"stevesbotApiUrl": "http://10.0.0.30:8787",
"stevesbotChannelProducts": {
    "746573900715917334": "vdo-ninja",
    "877898730240634920": "social-stream"
}
```

## How it works
1. User creates support thread → existing welcome message shows **Close Thread** | **Change Title** | **Ask the Bot**
2. User clicks **Ask the Bot** → Discord bot calls StevesBot API
3. StevesBot sends product/platform selection buttons in the thread
4. User completes triage → StevesBot searches docs and support history for an answer

## StevesBot side
The corresponding `/api/start-triage` endpoint is already deployed on the Pi (aliases the existing test-triage endpoint).

## Test plan
- [ ] Deploy to Discord bot server with config values
- [ ] Create a test thread in VDO.Ninja support channel
- [ ] Verify "Ask the Bot" button appears alongside existing buttons
- [ ] Click button → verify triage flow starts with VDO.Ninja pre-selected
- [ ] Verify thread creator can use button, non-creators cannot
- [ ] Test error case: stop StevesBot → click button → verify graceful error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)